### PR TITLE
Remove service pings and fix `onError` handler

### DIFF
--- a/packages/service-clients/package.json
+++ b/packages/service-clients/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "micro": "^9.3.4"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
     "escape-string-regexp": "^2.0.0"
   },
   "peerDependencies": {
-    "@base-cms/micro": "^1.21.1"
+    "@base-cms/micro": "^1.21.3"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/services/application/package.json
+++ b/services/application/package.json
@@ -19,10 +19,9 @@
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",
     "@identity-x/utils": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "micro": "^9.3.4",
     "mongoose": "^5.5.11",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "validator": "^11.0.0"
   },
   "devDependencies": {

--- a/services/application/package.json
+++ b/services/application/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@base-cms/utils": "^1.9.0",
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",

--- a/services/application/src/index.js
+++ b/services/application/src/index.js
@@ -21,7 +21,7 @@ service.jsonServer({
     await init();
   },
   onHealthCheck: ping,
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/application/src/ping.js
+++ b/services/application/src/ping.js
@@ -1,17 +1,5 @@
 const { ping } = require('@identity-x/utils').mongoose;
-// const {
-//   ipService,
-//   localeService,
-//   tokenService,
-//   organizationService,
-// } = require('@identity-x/service-clients');
 const connection = require('./mongodb/connection');
 const pkg = require('../package.json');
 
-module.exports = () => Promise.all([
-  ping({ connection, pkg })(),
-  // ipService.ping(),
-  // localeService.ping(),
-  // tokenService.ping(),
-  // organizationService.ping(),
-]);
+module.exports = ping({ connection, pkg });

--- a/services/export/package.json
+++ b/services/export/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@base-cms/object-path": "^1.9.0",
     "@identity-x/service-clients": "^0.11.0",
     "aws-sdk": "^2.610.0",

--- a/services/export/package.json
+++ b/services/export/package.json
@@ -17,11 +17,10 @@
     "@base-cms/micro": "^1.21.1",
     "@base-cms/object-path": "^1.9.0",
     "@identity-x/service-clients": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "aws-sdk": "^2.610.0",
     "json2csv": "^4.5.4",
     "micro": "^9.3.4",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "validator": "^11.0.0"
   },
   "devDependencies": {

--- a/services/export/src/index.js
+++ b/services/export/src/index.js
@@ -17,7 +17,7 @@ service.jsonServer({
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/export/src/index.js
+++ b/services/export/src/index.js
@@ -4,7 +4,6 @@ const newrelic = require('./newrelic');
 const { INTERNAL_PORT, EXTERNAL_PORT } = require('./env');
 const pkg = require('../package.json');
 const actions = require('./actions');
-const ping = require('./ping');
 
 const { log } = console;
 
@@ -18,7 +17,6 @@ service.jsonServer({
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onHealthCheck: ping,
   onError: newrelic.noticeError,
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,

--- a/services/export/src/ping.js
+++ b/services/export/src/ping.js
@@ -1,9 +1,0 @@
-// const {
-//   applicationService,
-//   mailerService,
-// } = require('@identity-x/service-clients');
-
-module.exports = () => Promise.all([
-  // applicationService.ping(),
-  // mailerService.ping(),
-]);

--- a/services/graphql/package.json
+++ b/services/graphql/package.json
@@ -17,7 +17,6 @@
     "@base-cms/utils": "^1.9.0",
     "@godaddy/terminus": "^4.2.0",
     "@identity-x/service-clients": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "apollo-newrelic-extension": "^0.1.1",
     "apollo-server-express": "^2.5.0",
     "deep-assign": "^3.0.0",
@@ -27,7 +26,7 @@
     "graphql-tools": "^4.0.4",
     "graphql-type-json": "^0.3.0",
     "mongodb": "3.2.5",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "object-path": "^0.11.4"
   },
   "devDependencies": {

--- a/services/graphql/src/index.js
+++ b/services/graphql/src/index.js
@@ -4,7 +4,6 @@ const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');
 const app = require('./app');
 const env = require('./env');
-const ping = require('./ping');
 const pkg = require('../package.json');
 const start = require('./app/start');
 const stop = require('./app/stop');
@@ -33,7 +32,7 @@ const run = async () => {
   createTerminus(server, {
     timeout: TERMINUS_TIMEOUT,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
-    healthChecks: { '/_health': () => ping() },
+    healthChecks: { '/_health': () => ({ ping: 'pong' }) },
     onSignal: async () => {
       // Stop required services here...
       log('Signal received, running cleanup hook...');

--- a/services/ip/package.json
+++ b/services/ip/package.json
@@ -15,10 +15,9 @@
   "dependencies": {
     "@base-cms/env": "^1.0.0",
     "@base-cms/micro": "^1.21.1",
-    "@newrelic/native-metrics": "^4.1.0",
     "ip6addr": "^0.2.2",
     "micro": "^9.3.4",
-    "newrelic": "^5.9.1"
+    "newrelic": "^6.4.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/services/ip/package.json
+++ b/services/ip/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "ip6addr": "^0.2.2",
     "micro": "^9.3.4",
     "newrelic": "^6.4.0"

--- a/services/ip/src/index.js
+++ b/services/ip/src/index.js
@@ -17,7 +17,7 @@ service.jsonServer({
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/locale/package.json
+++ b/services/locale/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "i18n-iso-countries": "^4.3.1",
     "micro": "^9.3.4",
     "newrelic": "^6.4.0"

--- a/services/locale/package.json
+++ b/services/locale/package.json
@@ -15,10 +15,9 @@
   "dependencies": {
     "@base-cms/env": "^1.0.0",
     "@base-cms/micro": "^1.21.1",
-    "@newrelic/native-metrics": "^4.1.0",
     "i18n-iso-countries": "^4.3.1",
     "micro": "^9.3.4",
-    "newrelic": "^5.9.1"
+    "newrelic": "^6.4.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/services/locale/src/index.js
+++ b/services/locale/src/index.js
@@ -17,7 +17,7 @@ service.jsonServer({
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/mailer/package.json
+++ b/services/mailer/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@sendgrid/mail": "^6.4.0",
     "micro": "^9.3.4",
     "newrelic": "^6.4.0"

--- a/services/mailer/package.json
+++ b/services/mailer/package.json
@@ -15,10 +15,9 @@
   "dependencies": {
     "@base-cms/env": "^1.0.0",
     "@base-cms/micro": "^1.21.1",
-    "@newrelic/native-metrics": "^4.1.0",
     "@sendgrid/mail": "^6.4.0",
     "micro": "^9.3.4",
-    "newrelic": "^5.9.1"
+    "newrelic": "^6.4.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/services/mailer/src/index.js
+++ b/services/mailer/src/index.js
@@ -17,7 +17,7 @@ service.jsonServer({
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/membership/package.json
+++ b/services/membership/package.json
@@ -19,10 +19,9 @@
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",
     "@identity-x/utils": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "micro": "^9.3.4",
     "mongoose": "^5.5.11",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "validator": "^11.0.0"
   },
   "devDependencies": {

--- a/services/membership/package.json
+++ b/services/membership/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@base-cms/utils": "^1.9.0",
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",

--- a/services/membership/src/index.js
+++ b/services/membership/src/index.js
@@ -21,7 +21,7 @@ service.jsonServer({
     await init();
   },
   onHealthCheck: ping,
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/membership/src/ping.js
+++ b/services/membership/src/ping.js
@@ -1,17 +1,5 @@
 const { ping } = require('@identity-x/utils').mongoose;
-// const {
-//   mailerService,
-//   organizationService,
-//   tokenService,
-//   userService,
-// } = require('@identity-x/service-clients');
 const connection = require('./mongodb/connection');
 const pkg = require('../package.json');
 
-module.exports = () => Promise.all([
-  ping({ connection, pkg })(),
-  // mailerService.ping(),
-  // organizationService.ping(),
-  // tokenService.ping(),
-  // userService.ping(),
-]);
+module.exports = ping({ connection, pkg });

--- a/services/organization/package.json
+++ b/services/organization/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@base-cms/utils": "^1.9.0",
     "@identity-x/utils": "^0.11.0",
     "micro": "^9.3.4",

--- a/services/organization/package.json
+++ b/services/organization/package.json
@@ -17,10 +17,9 @@
     "@base-cms/micro": "^1.21.1",
     "@base-cms/utils": "^1.9.0",
     "@identity-x/utils": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "micro": "^9.3.4",
     "mongoose": "^5.5.11",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "validator": "^11.0.0"
   },
   "devDependencies": {

--- a/services/organization/src/index.js
+++ b/services/organization/src/index.js
@@ -21,7 +21,7 @@ service.jsonServer({
     await init();
   },
   onHealthCheck: ping,
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/token/package.json
+++ b/services/token/package.json
@@ -16,11 +16,10 @@
     "@base-cms/env": "^1.0.0",
     "@base-cms/micro": "^1.21.1",
     "@identity-x/utils": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "jsonwebtoken": "^8.5.1",
     "micro": "^9.3.4",
     "mongoose": "^5.5.11",
-    "newrelic": "^5.9.1",
+    "newrelic": "^6.4.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/services/token/package.json
+++ b/services/token/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@identity-x/utils": "^0.11.0",
     "jsonwebtoken": "^8.5.1",
     "micro": "^9.3.4",

--- a/services/token/src/index.js
+++ b/services/token/src/index.js
@@ -21,7 +21,7 @@ service.jsonServer({
     await init();
   },
   onHealthCheck: ping,
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/user/package.json
+++ b/services/user/package.json
@@ -18,10 +18,9 @@
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",
     "@identity-x/utils": "^0.11.0",
-    "@newrelic/native-metrics": "^4.1.0",
     "micro": "^9.3.4",
     "mongoose": "^5.5.11",
-    "newrelic": "^5.9.1"
+    "newrelic": "^6.4.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/services/user/package.json
+++ b/services/user/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0",
-    "@base-cms/micro": "^1.21.1",
+    "@base-cms/micro": "^1.21.3",
     "@identity-x/mongoose-plugins": "^0.11.0",
     "@identity-x/service-clients": "^0.11.0",
     "@identity-x/utils": "^0.11.0",

--- a/services/user/src/index.js
+++ b/services/user/src/index.js
@@ -21,7 +21,7 @@ service.jsonServer({
     await init();
   },
   onHealthCheck: ping,
-  onError: newrelic.noticeError,
+  onError: e => newrelic.noticeError(e),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/user/src/ping.js
+++ b/services/user/src/ping.js
@@ -1,13 +1,5 @@
 const { ping } = require('@identity-x/utils').mongoose;
-// const {
-//   mailerService,
-//   tokenService,
-// } = require('@identity-x/service-clients');
 const connection = require('./mongodb/connection');
 const pkg = require('../package.json');
 
-module.exports = () => Promise.all([
-  ping({ connection, pkg })(),
-  // mailerService.ping(),
-  // tokenService.ping(),
-]);
+module.exports = ping({ connection, pkg });

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,10 +699,10 @@
     envalid "^5.0.0"
     validator "^11.0.0"
 
-"@base-cms/micro@^1.21.1":
-  version "1.21.1"
-  resolved "https://registry.yarnpkg.com/@base-cms/micro/-/micro-1.21.1.tgz#f8384fdb35e189bba23cdbc65af771f2d7c97e2b"
-  integrity sha512-ZVxV50CSlnJZ5lB05ig+d9eX4OfXu2GwjTqX2C9xRiemqneTS+q6HKQ+PFIypO2qMcoKT7Jv+QWuSimLDtbHcQ==
+"@base-cms/micro@^1.21.3":
+  version "1.21.3"
+  resolved "https://registry.yarnpkg.com/@base-cms/micro/-/micro-1.21.3.tgz#0df00e43db3de18aa3a9ec2a05e0d015f96e783e"
+  integrity sha512-zqHTPbQ6KzPihyYwiYa2z/DTWkgKk3ihCA92Czxoj8huO4HOG2/u/+aVwol8Dijf4e88xzGGAvxSkXH7lq/2dA==
   dependencies:
     "@base-cms/object-path" "^1.9.0"
     "@godaddy/terminus" "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,25 +1501,30 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@newrelic/koa@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@newrelic/koa/-/koa-1.0.8.tgz#59bf54e86cef700427e32dbdc7c931a213146ac1"
-  integrity sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==
+"@newrelic/aws-sdk@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/aws-sdk/-/aws-sdk-1.1.1.tgz#465ccd57a190b04b90aef5067e91ffdeb18e5c14"
+  integrity sha512-2ibXwCK7zZ7HDH5anus8l0ZksIMdxhqwyWmc6UHgqe4pyvT9Ush6K/IKvX3MTjjG9wYqovwSulHPCHtdk/IpSg==
+
+"@newrelic/koa@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/koa/-/koa-3.0.0.tgz#048f636c6c06ab4e823674a2ed3d67677a22ed50"
+  integrity sha512-SxfcMqSxiKa3pi7dRmVoCXnh/VLc196GmwyGU2Fr5+vMxS5jPVj2a15v1mn2DGu04XngfXDvyt9Xa6u1JVRDpQ==
   dependencies:
     methods "^1.1.2"
 
-"@newrelic/native-metrics@^4.0.0", "@newrelic/native-metrics@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz#cb1641e55179cd6ec058441ae0b0eedfa36ee0eb"
-  integrity sha512-7CZlKMLuaYQW7mV9qVyo9b9HVe2xBnyn+kkETRJoZGs5P7gdfv9AAE3RPhtOBUopTfbmc8ju7njYadjui9J1XA==
+"@newrelic/native-metrics@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/native-metrics/-/native-metrics-5.0.0.tgz#d31344e4fabf82e7187552dce1b1335ad097c01d"
+  integrity sha512-6Smx/9MlsZTcbLe+Co39O9kJ3sYo/3xunNTOhTP+nPlLxQmQBPDT0/ULmEogTkhaEX5MuCx6L4cN+1QU4uZdDw==
   dependencies:
-    nan "^2.12.1"
+    nan "^2.14.0"
     semver "^5.5.1"
 
-"@newrelic/superagent@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@newrelic/superagent/-/superagent-1.0.3.tgz#8c6ea84f8b463275c58e740204bf2939c2e2a649"
-  integrity sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==
+"@newrelic/superagent@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/superagent/-/superagent-2.0.0.tgz#48279c1ff8a720006202a2ca76c38c6de1c5e650"
+  integrity sha512-FrQfMhbv/HFB60wAQixbSjMk8hT+vS5ms6XJ9J40b9z6YI6x4/wgOc13GbvXbztcfOKCTeGVVDbBCruuh9udRA==
   dependencies:
     methods "^1.1.2"
 
@@ -2066,6 +2071,13 @@ agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
 
@@ -6666,6 +6678,18 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escodegen@^1.11.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
+  integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-airbnb-base@^13.1.0:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz#b5a1b480b80dfad16433d6c4ad84e6605052c05c"
@@ -6817,7 +6841,7 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6850,6 +6874,11 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+estraverse@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estree-walker@^0.6.1:
   version "0.6.1"
@@ -7085,7 +7114,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -8255,6 +8284,14 @@ https-proxy-agent@^2.2.1:
   integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
   dependencies:
     agent-base "^4.1.0"
+    debug "^3.1.0"
+
+https-proxy-agent@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
+  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
+  dependencies:
+    agent-base "^4.3.0"
     debug "^3.1.0"
 
 humanize-ms@^1.2.1:
@@ -10435,7 +10472,7 @@ najax@^1.0.3:
     lodash.defaultsdeep "^4.6.0"
     qs "^6.2.0"
 
-nan@^2.12.1, nan@^2.13.2:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -10481,22 +10518,25 @@ neo-async@^2.5.0, neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-newrelic@^5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-5.9.1.tgz#44c8628bb36eb2c478cf32932eb2c8c3b02353fe"
-  integrity sha512-WDhvtpV/zR6i/VSLCBY/xb2XZ9IQFuxkrJZTMfkyrUQYUyS1fWIXIhoBwOrwE4j0cKSS5TKpIrbz1ckdmnCq3A==
+newrelic@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-6.4.0.tgz#ff387082b2b929dad295b8bad87827795ca7f3b3"
+  integrity sha512-Xqxft7Cids3SxSIKMj1ABP1bePyjofuHMHU+wLZ/KOaKwQSyK8m+hZ7N+EDO/EYW/Q/ywVw4O3ydCrW3tmwG6Q==
   dependencies:
-    "@newrelic/koa" "^1.0.8"
-    "@newrelic/superagent" "^1.0.2"
+    "@newrelic/aws-sdk" "^1.1.1"
+    "@newrelic/koa" "^3.0.0"
+    "@newrelic/superagent" "^2.0.0"
     "@tyriar/fibonacci-heap" "^2.0.7"
     async "^2.1.4"
     concat-stream "^2.0.0"
-    https-proxy-agent "^2.2.1"
+    escodegen "^1.11.1"
+    esprima "^4.0.1"
+    https-proxy-agent "^3.0.0"
     json-stringify-safe "^5.0.0"
     readable-stream "^3.1.1"
     semver "^5.3.0"
   optionalDependencies:
-    "@newrelic/native-metrics" "^4.0.0"
+    "@newrelic/native-metrics" "^5.0.0"
 
 next-tick@^1.0.0:
   version "1.0.0"
@@ -10972,6 +11012,18 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -14210,6 +14262,11 @@ windows-release@^3.1.0:
   integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
   dependencies:
     execa "^1.0.0"
+
+word-wrap@~1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
- remove commented out service-to-service pings
- directly invoke `newrelic.noticeError` in the `onError` service hook
- upgrade `newrelic` to 6.4.0 and remove the `@newrelic/native-metrics` package (it is directly included by the `newrelic` package)
- upgrade `@base-cms/micro` to include a fix/patch for when the `onError` handler fails