### PR TITLE
Set New Relic transaction names using service action

### DIFF
--- a/services/export/src/index.js
+++ b/services/export/src/index.js
@@ -14,17 +14,15 @@ process.on('unhandledRejection', (e) => {
 
 service.jsonServer({
   actions,
+  context: ({ input }) => {
+    const { action } = input;
+    newrelic.setTransactionName(action);
+    return {};
+  },
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: (e) => {
-    const status = e.statusCode || e.status || 500;
-    if (status >= 500) {
-      newrelic.noticeError(e);
-    } else {
-      log('Error not sent to New Relic.');
-    }
-  },
+  onError: newrelic.noticeError.bind(newrelic),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/ip/src/index.js
+++ b/services/ip/src/index.js
@@ -14,17 +14,15 @@ process.on('unhandledRejection', (e) => {
 
 service.jsonServer({
   actions,
+  context: ({ input }) => {
+    const { action } = input;
+    newrelic.setTransactionName(action);
+    return {};
+  },
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: (e) => {
-    const status = e.statusCode || e.status || 500;
-    if (status >= 500) {
-      newrelic.noticeError(e);
-    } else {
-      log('Error not sent to New Relic.');
-    }
-  },
+  onError: newrelic.noticeError.bind(newrelic),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/locale/src/index.js
+++ b/services/locale/src/index.js
@@ -14,17 +14,15 @@ process.on('unhandledRejection', (e) => {
 
 service.jsonServer({
   actions,
+  context: ({ input }) => {
+    const { action } = input;
+    newrelic.setTransactionName(action);
+    return {};
+  },
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: (e) => {
-    const status = e.statusCode || e.status || 500;
-    if (status >= 500) {
-      newrelic.noticeError(e);
-    } else {
-      log('Error not sent to New Relic.');
-    }
-  },
+  onError: newrelic.noticeError.bind(newrelic),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/mailer/src/index.js
+++ b/services/mailer/src/index.js
@@ -14,17 +14,15 @@ process.on('unhandledRejection', (e) => {
 
 service.jsonServer({
   actions,
+  context: ({ input }) => {
+    const { action } = input;
+    newrelic.setTransactionName(action);
+    return {};
+  },
   onStart: async () => {
     log(`> Booting ${pkg.name} v${pkg.version}...`);
   },
-  onError: (e) => {
-    const status = e.statusCode || e.status || 500;
-    if (status >= 500) {
-      newrelic.noticeError(e);
-    } else {
-      log('Error not sent to New Relic.');
-    }
-  },
+  onError: newrelic.noticeError.bind(newrelic),
   port: INTERNAL_PORT,
   exposedPort: EXTERNAL_PORT,
 }).catch(e => setImmediate(() => {

--- a/services/token/src/actions/invalidate.js
+++ b/services/token/src/actions/invalidate.js
@@ -3,6 +3,6 @@ const Token = require('../mongodb/models/token');
 
 module.exports = async ({ jti } = {}) => {
   if (!jti) throw createRequiredParamError('jti');
-  await Token.remove({ _id: jti });
+  await Token.deleteOne({ _id: jti });
   return 'ok';
 };

--- a/services/token/src/actions/verify.js
+++ b/services/token/src/actions/verify.js
@@ -23,7 +23,7 @@ module.exports = async ({ token, sub }) => {
     // Ensure the token exists in the db and matches the subject.
     const { jti } = verified;
     const doc = await Token.findById(jti);
-    if (!doc) throw createError(400, 'No token was found for the provided token identifier.');
+    if (!doc) throw createError(404, 'No token was found for the provided token identifier.');
     if (sub !== doc.sub) throw createError(400, 'The token subject does not match.');
     return verified;
   } catch (e) {
@@ -32,7 +32,7 @@ module.exports = async ({ token, sub }) => {
       case 'invalid signature':
         throw createError(400, message);
       case 'jwt expired':
-        throw createError(400, message);
+        throw createError(401, message);
       case 'jwt malformed':
         throw createError(422, message);
       default:


### PR DESCRIPTION
- set the NR transaction name based on the current action
- always send errors to NR (the internally policies will now set these errors as expected, when a 400)
- use 404 for no token found and 401 for token expired
- replace the deprecated `Model.remove` method with `Model.deleteOne`