### PR TITLE
Change user export sort field from `updatedAt` to `createdAt`

### DIFF
--- a/services/export/src/actions/user/export-for-app.js
+++ b/services/export/src/actions/user/export-for-app.js
@@ -58,7 +58,7 @@ module.exports = async ({
         regionalConsentPolicies: getAsArray(org, 'regionalConsentPolicies'),
         params: {
           id: applicationId,
-          sort: { field: 'updatedAt', order: 'desc' },
+          sort: { field: 'createdAt', order: 'desc' },
         },
         stream: parser.input,
       });


### PR DESCRIPTION
GQL query to return user records was updated a while back to sort by updated date.  Not all records have that element populated (new registrations), and aren't returned in the result set as a result.  Changed to sort by created which is consistent and will return full exports as expected.