### PR TITLE
updated reducer to not eliminate columns from export when first item in resultset has null value for it

### DIFF
--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -30,11 +30,7 @@ const executor = async (args) => {
   const nodes = getAsArray(data, 'edges').map((edge) => {
     const { node } = edge;
 
-    const reducer = (o, field) => {
-      const v = (node[field] === undefined) ? '' : node[field];
-      return { ...o, [field]: v };
-    };
-    const row = fields.reduce(reducer, {});
+    const row = fields.reduce((o, field) => ({ ...o, [field]: node[field] == null ? '' : node[field] }), {});
 
     const consentAnswers = getAsArray(node, 'regionalConsentAnswers');
     const answers = regionalConsentPolicies.reduce((o, policy) => {

--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -29,7 +29,13 @@ const executor = async (args) => {
   });
   const nodes = getAsArray(data, 'edges').map((edge) => {
     const { node } = edge;
-    const row = fields.reduce((o, field) => ({ ...o, [field]: node[field] }), {});
+
+    const reducer = (o, field) => {
+      const v = (node[field] === undefined) ? '' : node[field];
+      return { ...o, [field]: v };
+    };
+    const row = fields.reduce(reducer, {});
+
     const consentAnswers = getAsArray(node, 'regionalConsentAnswers');
     const answers = regionalConsentPolicies.reduce((o, policy) => {
       const answer = consentAnswers.find(v => v._id === policy._id);


### PR DESCRIPTION
Report in DEV-16, number of columns in user exports vary at time.  Found to be dictated by first result in response being used to determine fields became columns via reduce which eliminated when null.  Updated to set to empty string so results 2->n that do have data can display it.