### PR TITLE
Add `setAppUserUnverifiedData` mutation

### DIFF
--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -13,6 +13,7 @@ const logout = require('./logout');
 const manageCreate = require('./manage-create');
 const regionalConsentAnswer = require('./regional-constent-answer');
 const sendLoginLink = require('./send-login-link');
+const setUnverifiedData = require('./set-unverified-data');
 const updateCustomSelectAnswers = require('./update-custom-select-answers');
 const updateOne = require('./update-one');
 const verifyAuth = require('./verify-auth');
@@ -30,6 +31,7 @@ module.exports = {
   matchForApp: params => matchForApp(AppUser, params),
   regionalConsentAnswer,
   sendLoginLink,
+  setUnverifiedData,
   updateField: params => updateField(AppUser, params),
   updateFieldWithApp: params => updateFieldWithApp(AppUser, params),
   updateCustomSelectAnswers,

--- a/services/application/src/actions/user/set-unverified-data.js
+++ b/services/application/src/actions/user/set-unverified-data.js
@@ -1,0 +1,30 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { isObject, asArray } = require('@base-cms/utils');
+const setConsentAnswer = require('./utils/set-regional-consent-answer');
+
+const { AppUser } = require('../../mongodb/models');
+
+module.exports = async ({ applicationId, email, payload } = {}) => {
+  if (!email) throw createRequiredParamError('email');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+  if (!isObject(payload)) throw createRequiredParamError('payload');
+
+  const user = await AppUser.findByEmail(applicationId, email);
+  if (!user) throw createError(404, `No user was found for '${email}'`);
+
+  // do nothing if the user is already verified.
+  if (user.verified) return user;
+
+  const { regionalConsentAnswers, ...fields } = payload;
+
+  // overwrite/set regional consent answers
+  user.set('regionalConsentAnswers', []);
+  asArray(regionalConsentAnswers).forEach(({ policyId, given }) => {
+    setConsentAnswer({ user, policyId, given });
+  });
+
+  // set fields
+  user.set(fields);
+  return user.save();
+};

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -26,6 +26,9 @@ extend type Mutation {
 
   updateAppUserCustomSelectAnswers(input: UpdateAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
   updateOwnAppUserCustomSelectAnswers(input: UpdateOwnAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
+
+  "Sets field data to an unverified app user only. Is used for collecting user info before a login link is sent/used."
+  setAppUserUnverifiedData(input: SetAppUserUnverifiedDataMutationInput!): AppUser! @requiresApp # must be public
 }
 
 enum AppUserSortField {
@@ -218,6 +221,21 @@ input SetAppUserRegionalConsentAnswerInput {
   policyId: String!
   "Whether consent was given for this region."
   given: Boolean!
+}
+
+input SetAppUserUnverifiedDataMutationInput {
+  "The email address of the unverified user to set."
+  email: String!
+
+  givenName: String
+  familyName: String
+  organization: String
+  organizationTitle: String
+  countryCode: String
+  regionCode: String
+  postalCode: String
+
+  regionalConsentAnswers: [SetAppUserRegionalConsentAnswerInput!] = []
 }
 
 input UpdateAppUserPayloadInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -311,6 +311,41 @@ module.exports = {
     /**
      *
      */
+    setAppUserUnverifiedData: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const {
+        email,
+        givenName,
+        familyName,
+        organization,
+        organizationTitle,
+        countryCode,
+        regionCode,
+        postalCode,
+        regionalConsentAnswers,
+      } = input;
+
+      const payload = {
+        givenName,
+        familyName,
+        organization,
+        organizationTitle,
+        countryCode,
+        regionCode,
+        postalCode,
+        regionalConsentAnswers,
+      };
+
+      return applicationService.request('user.setUnverifiedData', {
+        applicationId,
+        email,
+        payload,
+      });
+    },
+
+    /**
+     *
+     */
     updateAppUser: (_, { input }, { app }) => {
       const applicationId = app.getId();
       const { id, payload } = input;


### PR DESCRIPTION
Adds support for saving user data to unverified app users. Data will only be applied if the user is unverified - verified users are skipped. This was primarily added support setting data to a user before they've received and used a login link. In other words, user questions can be asked and answered prior to the user logging in.